### PR TITLE
memory management  and ARC

### DIFF
--- a/Lightstreamer Thread Pool Library/LSURLDispatcher.m
+++ b/Lightstreamer Thread Pool Library/LSURLDispatcher.m
@@ -76,7 +76,7 @@
 #pragma mark -
 #pragma mark LSURLDispatcher statics
 
-static LSURLDispatcher *__sharedDispatcher= nil;
+static LSURLDispatcher *__sharedDispatcher = nil;
 static NSUInteger __maxLongRunningRequestsPerEndPoint= DEFAULT_MAX_LONG_RUNNING_REQUESTS_PER_ENDPOINT;
 
 
@@ -108,8 +108,6 @@ static NSUInteger __maxLongRunningRequestsPerEndPoint= DEFAULT_MAX_LONG_RUNNING_
 	@synchronized ([LSURLDispatcher class]) {
 		if (__sharedDispatcher) {
 			[__sharedDispatcher stopThreads];
-			
-			__sharedDispatcher= nil;
 		}
 	}
 }
@@ -154,7 +152,8 @@ static NSUInteger __maxLongRunningRequestsPerEndPoint= DEFAULT_MAX_LONG_RUNNING_
 }
 
 - (void) dealloc {
-	[LSURLDispatcher dispose];
+    // It's called in case if instance was created bypassing a sharedDispatcher initialization
+    [__sharedDispatcher stopThreads];
 }
 
 

--- a/Lightstreamer Thread Pool Library/LSURLDispatcher.m
+++ b/Lightstreamer Thread Pool Library/LSURLDispatcher.m
@@ -153,7 +153,7 @@ static NSUInteger __maxLongRunningRequestsPerEndPoint= DEFAULT_MAX_LONG_RUNNING_
 
 - (void) dealloc {
     // It's called in case if instance was created bypassing a sharedDispatcher initialization
-    [__sharedDispatcher stopThreads];
+    [self stopThreads];
 }
 
 


### PR DESCRIPTION
I removed "nil" assignment to the __sharedDispatcher, because the  __sharedDispatcher is static variable and it lives for all application running. In this case dealloc method is never called. Within disposal method  the stopThreads remained only. 
In the former dispose method: If we call dispose method and after that to call sharedDispatcher method again we will have new instance of sharedDispatcher but the system didn't release a previous __sharedDispatcher variable by reason that it's static variable. 
